### PR TITLE
pull site info from config

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -22,3 +22,7 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 #     import_config "#{Mix.env}.exs"
+
+config StatusApp,
+  sites: ["sheldonkreger.com", "prodrumblog.com"],
+  interval: 1000

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule StatusApp.Mixfile do
   use Mix.Project
 
   def project do
-    [app: :statusApp,
+    [app: StatusApp,
      version: "0.0.1",
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,


### PR DESCRIPTION
Prior to this commit, the sites to check were hardcoded as child workers
in the supervisor. This commit pulls those sites out to configuration
and then dynamically creates the child workers by reading the
configuration at startup.